### PR TITLE
Fix compilation error bad-function-cast.

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -4095,7 +4095,7 @@ static int lfs_fs_preporphans(lfs_t *lfs, int8_t orphans) {
     LFS_ASSERT(lfs_tag_size(lfs->gstate.tag) > 0 || orphans >= 0);
     lfs->gstate.tag += orphans;
     lfs->gstate.tag = ((lfs->gstate.tag & ~LFS_MKTAG(0x800, 0, 0)) |
-            ((uint32_t)lfs_gstate_hasorphans(&lfs->gstate) << 31));
+            (lfs_gstate_hasorphans(&lfs->gstate) ? (1ul << 31) : 0));
 
     return 0;
 }


### PR DESCRIPTION
error: cast from function call of type '_Bool' to non-matching type 'unsigned int' [-Werror=bad-function-cast]